### PR TITLE
Enable DRF browsable API

### DIFF
--- a/apps/content/urls.py
+++ b/apps/content/urls.py
@@ -10,5 +10,5 @@ router = DefaultRouter()
 router.register('content', views.ContentViewSet, 'Content')
 
 urlpatterns = [
-    path('', include(router.urls))
+    path('api/content/', include(router.urls))
 ]

--- a/project/settings.py
+++ b/project/settings.py
@@ -202,12 +202,14 @@ WORKERS_PURGE = 1000
 REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'djangorestframework_camel_case.render.CamelCaseJSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_PARSER_CLASSES': (
         'djangorestframework_camel_case.parser.CamelCaseJSONParser',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',

--- a/project/urls.py
+++ b/project/urls.py
@@ -3,6 +3,8 @@ from django.conf.urls import url, include
 from django.conf.urls.static import static
 from django.contrib import admin
 
+from .views import api_root
+
 
 admin.site.site_title = settings.ADMIN_TITLE
 admin.site.site_header = settings.ADMIN_HEADER
@@ -18,6 +20,10 @@ urlpatterns = [
     url(r'^', include('apps.user.urls')),
     url(r'^', include('apps.proxyexample.urls')),
     url(r'^', include('apps.workerexample.urls')),
+
+    # Browsable API
+    url(r'^api/$', api_root, name='index'),
+    url(r'^api-auth/', include('rest_framework.urls')),
 ]
 
 if settings.ENV == settings.DEV:

--- a/project/views.py
+++ b/project/views.py
@@ -1,0 +1,10 @@
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+
+
+@api_view(['GET'])
+def api_root(request, format=None):
+    return Response({
+        'users': reverse('user-list', request=request, format=format),
+    })


### PR DESCRIPTION
It's been set-up and useful for pretty much all the projects I've worked on, is there a reason it isn't installed in the starter by default?