### PR TITLE
Return token on user creation

### DIFF
--- a/apps/user/views.py
+++ b/apps/user/views.py
@@ -25,9 +25,13 @@ class Me(generics.RetrieveUpdateDestroyAPIView):
 
 
 class UserCreate(generics.CreateAPIView):
-    queryset = get_user_model().objects.all()
     serializer_class = UserSerializer
     permission_classes = (permissions.AllowAny,)
+
+    def post(self, request, *args, **kwargs):
+        response = super().post(request, *args, **kwargs)
+        token = Token.objects.create(user_id=response.data['id'])
+        return Response({'token': token.key, 'userId': token.user_id})
 
 
 class UserList(generics.ListAPIView):

--- a/apps/user/views.py
+++ b/apps/user/views.py
@@ -1,8 +1,8 @@
 from django.contrib.auth import get_user_model
-from rest_framework import generics, permissions
+from rest_framework import generics, permissions, status
+from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.response import Response
-from rest_framework.authtoken.models import Token
 
 from .serializers import (
     UserSerializer,
@@ -31,7 +31,10 @@ class UserCreate(generics.CreateAPIView):
     def post(self, request, *args, **kwargs):
         response = super().post(request, *args, **kwargs)
         token = Token.objects.create(user_id=response.data['id'])
-        return Response({'token': token.key, 'userId': token.user_id})
+        return Response(
+            {'token': token.key, 'userId': token.user_id},
+            status=status.HTTP_201_CREATED,
+        )
 
 
 class UserList(generics.ListAPIView):


### PR DESCRIPTION
Resolves the main motivation behind #27, albeit in the view and not the serializer.

Let me know if you'd prefer I do this in the serializer than the view, (or in a purpose-built serializer for user creation as per the example).