### PR TITLE
Disable Session Authentication for DRF.

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -191,7 +191,8 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
-        'rest_framework.authentication.SessionAuthentication',
+        # Only needed for DRF browsable API. Unfortunately, it can interfere with mobile app API requests.
+        # 'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',


### PR DESCRIPTION
Hard to reproduce, but some mobile app users interacting with our APIs on certain projects would receive: `{"detail":"CSRF Failed: Referer checking failed - no Referer."}` when POSTing. This addresses that issue.