### PR TITLE
Disable async in shell

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -175,7 +175,7 @@ LOGGING = {
 }
 logging.config.dictConfig(LOGGING)
 
-# If we're in shell, disable async so models aren't a fucking pain to query
+# If we're in shell, disable async so working with models is less painful
 if SHELL:
     os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -23,6 +23,7 @@ DEV = 'dev'
 STAGING = 'staging'
 PRODUCTION = 'production'
 TESTING = 'test' in sys.argv
+SHELL = 'shell' in sys.argv
 ENV = get('DJANGO_ENV')
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__))).replace('/project', '')
@@ -173,6 +174,10 @@ LOGGING = {
     }
 }
 logging.config.dictConfig(LOGGING)
+
+# If we're in shell, disable async so models aren't a fucking pain to query
+if SHELL:
+    os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
 
 # ==================================================================================================


### PR DESCRIPTION
When using Django 3.1+ models default to using async. Added a setting to disable this when in shell otherwise its a huge pain to grok stuffs.