### PR TITLE
Webhook notify

### DIFF
--- a/apps/webhook/README.md
+++ b/apps/webhook/README.md
@@ -1,0 +1,17 @@
+# Webhook App
+
+This app is for configuring webhooks to hit based on certain Django events. For example, hitting a webhook when new data is saved.
+
+Usage
+-----
+
+1. Add it to your Django installed apps:
+```python
+INSTALLED_APPS = [
+    # ...
+    'apps.webhook',
+    # ...
+]
+```
+2. Add a build hook on your Netlify project ([Netlify docs](https://docs.netlify.com/configure-builds/build-hooks/#parameters))
+3. Copy the URL and add it via the Django admin `admin/webhook/webhook`

--- a/apps/webhook/README.md
+++ b/apps/webhook/README.md
@@ -1,6 +1,8 @@
 # Webhook App
 
-This app is for configuring webhooks to hit based on certain Django events. For example, hitting a webhook when new data is saved.
+This app is for notifying webhooks when certain models are saved. The primary use-case, is to trigger Netlify deploys when certain models are created/updated. That way, the front-end will refresh it's API requests cache for faster loading when visited.
+
+For now, the app is very simple, and requires configuration via code. If the use-cases or needs of this app expand, it could be modified to allow configuration via the Django admin.
 
 Usage
 -----
@@ -14,4 +16,5 @@ INSTALLED_APPS = [
 ]
 ```
 2. Add a build hook on your Netlify project ([Netlify docs](https://docs.netlify.com/configure-builds/build-hooks/#parameters))
-3. Copy the URL and add it via the Django admin `admin/webhook/webhook`
+3. Copy the URL and add it as an environment variable, `WEBHOOKS_NOTIFY_URL`
+4. Edit `apps/webhook/signals.py` to configure when to notify the webhook

--- a/apps/webhook/__init__.py
+++ b/apps/webhook/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'apps.webhook.apps.WebhookConfig'

--- a/apps/webhook/admin.py
+++ b/apps/webhook/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/apps/webhook/apps.py
+++ b/apps/webhook/apps.py
@@ -1,0 +1,18 @@
+import logging
+
+from django.apps import AppConfig
+
+
+log = logging.getLogger(__name__)
+
+
+class WebhookConfig(AppConfig):
+    name = 'apps.webhook'
+
+    def ready(self):
+        from django.conf import settings
+
+        if not settings.WEBHOOKS_NOTIFY_URL:
+            log.warning("WEBHOOKS_NOTIFY_URL not set, but 'apps.webhook' is installed.")
+        else:
+            from . import signals

--- a/apps/webhook/libs.py
+++ b/apps/webhook/libs.py
@@ -1,0 +1,12 @@
+import requests
+from django.conf import settings
+
+
+def notify(title='Triggered by Djano signal', branch='master'):
+    response = requests.post(
+        settings.WEBHOOKS_NOTIFY_URL,
+        params={'trigger_title': title, 'trigger_branch': branch},
+    )
+    if (response.status_code < 200) or (response.status_code > 299):
+        raise Exception(response.text)
+    return response

--- a/apps/webhook/models.py
+++ b/apps/webhook/models.py
@@ -1,0 +1,19 @@
+# from django.db import models
+
+
+# class Webhook(models.Model):
+#     url = models.URLField()
+#     name = models.CharField(max_length=255)
+#     app_name = models.CharField(max_length=32)
+#     model_name = models.CharField(max_length=128, blank=True)
+#     signal_type = models.CharField(max_length=32)
+#     enabled = models.BooleanField(default=True)
+
+#     class Meta:
+#         unique_together = (('url', 'model_name', 'signal_type'), )
+
+#     def __unicode__(self):
+#         return u'%s' % self.signal_name
+
+#     def __str__(self):
+#         return self.signal_name

--- a/apps/webhook/signals.py
+++ b/apps/webhook/signals.py
@@ -1,0 +1,22 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from apps.cms.models.post import Post
+
+from .libs import notify
+
+
+@receiver(post_save, sender=Post, dispatch_uid='post_post_save_webhook')
+def post_webhook_signal(sender, instance, created, **kwargs):
+    """ Here's an example signal to trigger a webhook.
+
+    If a Post is created, we notify our configured webhook url (see project/settings.py).
+    For now, the notify function accepts two params: title and branch, as this can be passed
+    to Netlify.
+
+    Both params are optional with the following defaults:
+        title: 'Triggered by Django signal'
+        branch: 'master'
+    """
+    title = 'Triggered by new post' if created else 'Triggered by updated post'
+    notify(title=title, branch='master')

--- a/apps/webhook/tests.py
+++ b/apps/webhook/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/apps/webhook/views.py
+++ b/apps/webhook/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/project/settings.py
+++ b/project/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     'apps.mail',
     'apps.socialmedia',
     'apps.user',
+    'apps.webhook',
 
     # ___CHANGEME___
     # Example apps
@@ -307,3 +308,6 @@ if EMAIL_PROVIDER == 'smtp':
 
 SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY')
 SENDGRID_URL = 'https://api.sendgrid.com/v3/mail/send'
+
+# Webhooks
+WEBHOOKS_NOTIFY_URL = os.environ.get('WEBHOOKS_NOTIFY_URL')


### PR DESCRIPTION
For triggering Netlify rebuilds/deploys when new data is saved to the API.

### Considerations/Todo

- Use worker task to post to webhook
- When triggering new worker task, clear any prior tasks still `waiting`
- Configuration to rate-limit