### PR TITLE
set x-frame-options

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -137,6 +137,8 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
+X_FRAME_OPTIONS = 'SAMEORIGIN'
+
 LOGGING_CONFIG = None
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
Setting x-frame-options to 'SAMEORIGIN' to enable loading Django admin iframes.

https://docs.djangoproject.com/en/4.1/ref/clickjacking/
